### PR TITLE
feat: SQLite session reader for OpenCode 1.2

### DIFF
--- a/src/plugins/types/agent.ts
+++ b/src/plugins/types/agent.ts
@@ -34,6 +34,8 @@ export interface SessionParseOptions {
   sessionId?: string;
   timePeriod?: 'session' | 'daily' | 'weekly' | 'monthly';
   limit?: number;
+  /** Epoch ms — only return sessions updated after this timestamp. */
+  since?: number;
 }
 
 export interface SessionUsageData {

--- a/src/tui/contexts/DashboardRuntimeContext.tsx
+++ b/src/tui/contexts/DashboardRuntimeContext.tsx
@@ -46,7 +46,11 @@ export function DashboardRuntimeProvider({ children }: { children: ReactNode }) 
     const currentTime = Date.now();
     
     const lastEntry = historyRef.current[historyRef.current.length - 1];
-    if (lastEntry && totalTokens < lastEntry.tokens) {
+    const isDiscontinuity = lastEntry && (
+      totalTokens < lastEntry.tokens ||
+      totalTokens > lastEntry.tokens * 2
+    );
+    if (isDiscontinuity) {
       historyRef.current = [];
     }
     


### PR DESCRIPTION
## Summary

- Adds SQLite-first session/message reader for OpenCode 1.2 (which moved from JSON flat files to `opencode.db`)
- Preserves JSON reader as fallback for older OpenCode versions
- Implements two-phase startup: scoped fast load based on user's default time window, then full backfill

## Changes

### `src/plugins/agents/opencode.ts`
- SQLite connection management with WAL checkpoint release (reopens every 5 min)
- Cached prepared statements (7 statements covering all query patterns)
- `parseSessionsSqlite()` — single joined query with `json_extract` filtering, `since` support, per-session aggregate cache
- `startActivityWatchSqlite()` — polls `part` table every 1s for real-time activity
- JSON functions renamed to `parseSessionsJson`, `startActivityWatchJson`, `stopActivityWatchJson`
- Plugin dispatch: tries SQLite first, falls back to JSON
- Scope-aware session cache (`lastSince` field) prevents backfill cache collisions

### `src/plugins/types/agent.ts`
- Added `since?: number` to `SessionParseOptions` for time-scoped queries

### `src/tui/contexts/AgentSessionContext.tsx`
- Two-phase load: initial scoped request (`since = windowMs ago`) → immediate full backfill

### `src/tui/contexts/DashboardRuntimeContext.tsx`
- Discontinuity detection: resets KPI history when tokens more than double (backfill) or decrease (window change), preventing phantom cost spikes

## Testing
- TypeScript typecheck: clean
- Unit tests: 23/23 pass
- Driver snapshots verified: 1h window (6 sessions), 30d (1160 sessions), all-time (1560 sessions)

Closes #1