### PR TITLE
fix(providers): support zhipuai-coding-plan auth key

### DIFF
--- a/src/plugins/providers/zai.ts
+++ b/src/plugins/providers/zai.ts
@@ -64,7 +64,9 @@ export const zaiCodingPlanPlugin: ProviderPlugin = {
   auth: {
     async discover(ctx: PluginContext): Promise<CredentialResult> {
       // 1. Try OpenCode auth (api, wellknown, or oauth)
-      const entry = await ctx.authSources.opencode.getProviderEntry("zai-coding-plan");
+      const entry =
+        (await ctx.authSources.opencode.getProviderEntry("zhipuai-coding-plan")) ||
+        (await ctx.authSources.opencode.getProviderEntry("zai-coding-plan"));
       if (entry) {
         if (entry.type === "api" && entry.key) {
           return { ok: true, credentials: { apiKey: entry.key, source: "opencode" } };


### PR DESCRIPTION
OpenCode stores Zhipu AI credentials under the key "zhipuai-coding-plan", but the Z.ai provider only checked for "zai-coding-plan" when discovering credentials from OpenCode auth. This caused the provider to show as "unconfigured" for users with Zhipu AI Coding Plan subscriptions. This fix adds support for the "zhipuai-coding-plan" key while retaining "zai-coding-plan"