### PR TITLE
feat: add OpenCode wrapper script for automatic tokentop launch on exit

### DIFF
--- a/scripts/opencode-wrapper.sh
+++ b/scripts/opencode-wrapper.sh
@@ -26,10 +26,13 @@ fi
 echo "   Detected shell: $DETECTED_SHELL"
 
 # Define the wrapper function
-WRAPPER_CODE='# OpenCode wrapper - launch tokentop (ttop) on exit
+WRAPPER_CODE='# OpenCode wrapper - launch tokentop (ttop) on exit (interactive terminals only)
 opencode() {
   command opencode "$@"
-  ttop
+  # Only launch ttop if running in an interactive terminal
+  if [ -t 1 ] && [[ $- == *i* ]]; then
+    ttop
+  fi
 }'
 
 # Find the first existing config file


### PR DESCRIPTION
## Summary
Adds a shell wrapper script that automatically launches tokentop (ttop) after OpenCode exits, making it easy to review your token usage immediately after a coding session.

## Changes
- New script: `scripts/opencode-wrapper.sh`
- Detects user's shell (bash/zsh) automatically
- Adds `opencode()` wrapper function to shell config
- Only launches `ttop` in interactive terminals (headless/CI/script execution respects this)
- Backs up existing config before modification
- Idempotent: safe to run multiple times

## Type
- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, deps, CI, or tooling
- [ ] `test` — Adding or updating tests

## Related issues
N/A (new feature)

## Testing
- [ ] `bun test` passes (N/A - shell script, no TypeScript unit tests)
- [ ] `bun run typecheck` passes (N/A - shell script)
- [x] Manual verification (describe below)

## Manual Verification
1. Downloaded and tested script with `chmod +x scripts/opencode-wrapper.sh && ./scripts/opencode-wrapper.sh`
2. Verified shell detection works for zsh
3. Verified backup file creation before modification
4. Verified idempotent behavior (running twice succeeds with appropriate message)
5. Verified wrapper function format matches expected output
6. Checked script syntax with bash -n check
7. Verified interactive mode detection: `ttop` only launches when `tty` present and shell is interactive

## What it does
The wrapper adds a shell function that:
1. Wraps the `opencode` command
2. Automatically launches `ttop` when OpenCode exits (interactive terminals only)
3. Checks for interactive mode using `[ -t 1 ] && [[ 569X == *i* ]]`
4. Prevents UI issues in headless/script execution

## Why this matters
Users coding with OpenCode want to see their token usage right after a session. This wrapper makes it automatic — no need to remember to run `ttop` manually. Interactive detection ensures scripts, CI, and headless execution won't break.

## Interactive Mode Detection
Uses robust checks:
- `[ -t 1 ]` - stdout is a terminal
- `[[ 569X == *i* ]]` - shell has interactive flag set

This ensures `ttop` only runs in true interactive sessions, not:\n- Cron jobs\n- CI pipelines\n- Piped commands\n- Script invocations