### PR TITLE
perf: virtualize session list to only render visible rows (#57)

### DIFF
--- a/src/tui/components/SessionsTable.tsx
+++ b/src/tui/components/SessionsTable.tsx
@@ -1,6 +1,6 @@
 import type { ScrollBoxRenderable } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
-import { forwardRef, memo, type Ref, useCallback, useRef } from "react";
+import { forwardRef, memo, type Ref, useCallback, useEffect, useRef } from "react";
 import type { AgentSessionAggregate } from "../../agents/types.ts";
 import { useColors } from "../contexts/ThemeContext.tsx";
 import { useAnimatedValue } from "../hooks/useAnimatedValue.ts";
@@ -9,6 +9,9 @@ import { useExitAnimation } from "../hooks/useExitAnimation.ts";
 import { interpolateColor, useValueFlash } from "../hooks/useValueFlash.ts";
 import type { SortDirection, SortField } from "../types/sort.ts";
 import { getSortDirectionIndicator, getSortFieldLabel } from "../types/sort.ts";
+
+/** Number of rows above/below the viewport to keep as full SessionRow components. */
+const VIRTUALIZATION_BUFFER = 3;
 
 interface SessionsTableProps {
   sessions: AgentSessionAggregate[];
@@ -21,6 +24,10 @@ interface SessionsTableProps {
   getProviderColor: (id: string) => string;
   sortField: SortField;
   sortDirection: SortDirection;
+  /** Number of session rows visible in the viewport. */
+  visibleRows: number;
+  /** Current scroll offset (row index at the top of the viewport). */
+  scrollOffset: number;
 }
 
 function extractRepoName(projectPath: string | null): string {
@@ -361,6 +368,8 @@ export const SessionsTable = forwardRef(function SessionsTable(
     getProviderColor,
     sortField,
     sortDirection,
+    visibleRows,
+    scrollOffset,
   }: SessionsTableProps,
   ref: Ref<ScrollBoxRenderable>,
 ) {
@@ -403,9 +412,24 @@ export const SessionsTable = forwardRef(function SessionsTable(
   const bulkCountRef = useRef(0);
   if (isBulkChange) bulkCountRef.current++;
 
+  // --- Virtualization: determine which rows get full SessionRow vs placeholder ---
+  const totalRows = animatedSessions.length;
+  const clampedOffset = Math.min(scrollOffset, Math.max(0, totalRows - 1));
+  const startIdx = Math.max(0, clampedOffset - VIRTUALIZATION_BUFFER);
+  const endIdx = Math.min(totalRows, clampedOffset + visibleRows + VIRTUALIZATION_BUFFER);
+
+  // Track known session IDs so we can skip entrance animation for
+  // rows revealed by scrolling (vs genuinely new sessions).
+  const prevSessionIdsRef = useRef<Set<string>>(new Set());
+
   let activeIndex = 0;
   const selectedSession = sessions[selectedRow] ?? null;
   const inspector = selectedSession ? getInspectorData(selectedSession) : null;
+
+  // Update known session IDs after render so next render can detect new vs scroll-revealed.
+  useEffect(() => {
+    prevSessionIdsRef.current = new Set(sessions.map((s) => s.sessionId));
+  }, [sessions]);
 
   // Sort indicator helpers for column headers
   const sortIndicator = (field: string) =>
@@ -532,8 +556,17 @@ export const SessionsTable = forwardRef(function SessionsTable(
               </text>
             </box>
           )}
-          {animatedSessions.map((entry) => {
+          {animatedSessions.map((entry, i) => {
             const isSelectedRow = !entry.isExiting && activeIndex++ === selectedRow;
+            const isInViewport = i >= startIdx && i < endIdx;
+
+            // Off-screen, non-exiting rows: lightweight placeholder (no hooks)
+            if (!isInViewport && !entry.isExiting) {
+              return <box key={entry.item.sessionId} height={1} />;
+            }
+
+            // Visible rows and exiting rows: full SessionRow with hooks
+            const isKnownSession = prevSessionIdsRef.current.has(entry.item.sessionId);
             return (
               <SessionRow
                 key={entry.item.sessionId}
@@ -544,7 +577,7 @@ export const SessionsTable = forwardRef(function SessionsTable(
                 getProviderColor={getProviderColor}
                 isExiting={entry.isExiting}
                 exitIntensity={entry.exitIntensity}
-                skipEntrance={isBulkChange}
+                skipEntrance={isBulkChange || isKnownSession}
                 terminalWidth={terminalWidth}
               />
             );

--- a/src/tui/hooks/useDashboardKeyboard.ts
+++ b/src/tui/hooks/useDashboardKeyboard.ts
@@ -88,6 +88,7 @@ interface DashboardKeyboardActions {
   setSelectedDriverIndex: (fn: (prev: number) => number) => void;
   setActiveDriverFilter: (val: string | null) => void;
   setShowSortOverlay: (val: boolean) => void;
+  clearSelectedSessionId: () => void;
 }
 
 interface UseDashboardKeyboardProps {
@@ -278,27 +279,39 @@ export function useDashboardKeyboard({
     if (focusedPanelRef.current === "sessions") {
       const sessions = sessionsRef.current;
       if (key.name === "down" || key.name === "j") {
+        pendingGRef.current = false;
         actions.setPendingG(false);
         actions.setSelectedRow((curr) => Math.min(curr + 1, sessions.length - 1));
       } else if (key.name === "up" || key.name === "k") {
+        pendingGRef.current = false;
         actions.setPendingG(false);
         actions.setSelectedRow((curr) => Math.max(curr - 1, 0));
       } else if (key.shift && key.name === "g") {
+        pendingGRef.current = false;
         actions.setPendingG(false);
+        actions.clearSelectedSessionId();
         actions.setSelectedRow(() => sessions.length - 1);
       } else if (key.name === "g") {
         if (pendingGRef.current) {
+          actions.clearSelectedSessionId();
           actions.setSelectedRow(() => 0);
           actions.setScrollOffset(0);
+          pendingGRef.current = false;
           actions.setPendingG(false);
         } else {
+          pendingGRef.current = true;
           actions.setPendingG(true);
-          setTimeout(() => actions.setPendingG(false), 500);
+          setTimeout(() => {
+            pendingGRef.current = false;
+            actions.setPendingG(false);
+          }, 500);
         }
       } else if (key.name === "return" && sessions.length > 0) {
+        pendingGRef.current = false;
         actions.setPendingG(false);
         actions.openSessionDrawer();
       } else {
+        pendingGRef.current = false;
         actions.setPendingG(false);
       }
     }

--- a/src/tui/views/RealTimeDashboard.tsx
+++ b/src/tui/views/RealTimeDashboard.tsx
@@ -86,9 +86,11 @@ export function RealTimeDashboard() {
   const [showSortOverlay, setShowSortOverlay] = useState(false);
   const [pendingG, setPendingG] = useState(false);
   const scrollOffsetRef = useRef(0);
+  const [scrollOffset, _setScrollOffsetState] = useState(0);
   const selectedSessionIdRef = useRef<string | null>(null);
   const setScrollOffset = useCallback((val: number) => {
     scrollOffsetRef.current = val;
+    _setScrollOffsetState(val);
     sessionsScrollboxRef.current?.scrollTo(val);
   }, []);
   const [limitSelectedIndex, setLimitSelectedIndex] = useState(0);
@@ -299,9 +301,12 @@ export function RealTimeDashboard() {
       newOffset = selectedRow - visibleRows + 1;
     }
 
-    scrollOffsetRef.current = newOffset;
-    sessionsScrollboxRef.current.scrollTo(newOffset);
-  }, [selectedRow, processedSessions.length, visibleRows]);
+    if (newOffset !== scrollOffsetRef.current) {
+      setScrollOffset(newOffset);
+    } else {
+      sessionsScrollboxRef.current.scrollTo(newOffset);
+    }
+  }, [selectedRow, processedSessions.length, visibleRows, setScrollOffset]);
 
   const openSessionDrawer = useCallback(() => {
     const session = processedSessions[selectedRow];
@@ -324,7 +329,7 @@ export function RealTimeDashboard() {
       sortField,
       sortDirection,
       pendingG,
-      scrollOffset: scrollOffsetRef.current,
+      scrollOffset,
       limitSelectedIndex,
       providerCount: configuredProviders.length,
       driverDimension,
@@ -351,6 +356,9 @@ export function RealTimeDashboard() {
       setSelectedDriverIndex,
       setActiveDriverFilter,
       setShowSortOverlay,
+      clearSelectedSessionId: () => {
+        selectedSessionIdRef.current = null;
+      },
     },
     processedSessions,
   });
@@ -496,6 +504,8 @@ export function RealTimeDashboard() {
           getProviderColor={providerColorOf}
           sortField={sortField}
           sortDirection={sortDirection}
+          visibleRows={visibleRows}
+          scrollOffset={scrollOffset}
         />
 
         {!effectiveSidebarCollapsed && (


### PR DESCRIPTION
## Summary

Virtualize the session list to reduce CPU usage and improve scroll performance with many sessions. Off-screen rows render as lightweight `<box height={1}>` placeholders instead of full `<SessionRow>` components (each mounting 5+ hooks).

## Changes

- Add placeholder-based virtualization to `SessionsTable`: rows outside `scrollOffset ± VIRTUALIZATION_BUFFER` render as 1-pixel boxes instead of full components
- Promote `scrollOffset` from ref-only to state+ref in `RealTimeDashboard` so placeholder ranges re-render on scroll jumps (gg, Shift+G)
- Sync `pendingGRef` directly in keyboard handler (not via useEffect) to fix `gg` when both g presses arrive in the same render frame
- Add `clearSelectedSessionId` action to prevent session stabilization from overriding explicit jump navigation

## Type

- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code change that neither fixes a bug nor adds a feature
- [ ] `docs` — Documentation only
- [ ] `chore` — Build, deps, CI, or tooling
- [ ] `test` — Adding or updating tests

## Related issues

Closes #57

## Testing

- [x] `bun test` passes (86 pass, 0 fail)
- [x] `bun run typecheck` passes
- [x] Manual verification (describe below)

TUI driver tests with 2295 live sessions (All Time window):
- gg (go to top): scrolls to row 0 with cursor on first session ✅
- Shift+G (go to bottom): scrolls to last row with cursor on last session ✅
- Repeated gg ↔ Shift+G cycles: consistent across multiple jumps ✅
- Arrow down/up navigation: smooth scrolling through virtualization boundary ✅
- Filter mode: sessions filter correctly with virtualized list ✅

## Screenshots / captures

N/A — virtualization is transparent to the user; no visual changes.