### PR TITLE
feat: tiered context-based pricing (>200K token threshold)

### DIFF
--- a/.sisyphus/evidence/task-5-mixed-bucket-pricing.txt
+++ b/.sisyphus/evidence/task-5-mixed-bucket-pricing.txt
@@ -1,0 +1,36 @@
+Task 5 Evidence — Mixed Bucket Pricing
+Date: 2026-04-06
+
+Files changed:
+- src/agents/costing.ts
+- src/agents/costing.test.ts
+
+Summary:
+- Updated priceStream() to price base and long-context buckets separately via estimateCost() and sum both buckets.
+- Preserved conservative fallback behavior when long-context pricing fields are absent.
+- Set stream.hasLongContext when longContextRequestCount > 0.
+- Updated priceSession() windowed costs to allocate base and long-context costs with per-bucket ratios.
+- Left estimateCost() signature unchanged.
+
+Test coverage added in src/agents/costing.test.ts:
+1. Base-only stream keeps existing behavior when tiered pricing metadata exists.
+2. Long-context-only stream uses tiered pricing.
+3. Mixed stream sums base and long-context buckets.
+4. Long-context stream without tiered pricing uses base rates conservatively.
+5. Empty long-context bucket avoids NaN/errors.
+6. Windowed session costs use per-bucket ratios instead of blended ratios.
+7. Multi-stream session handles mixed tiered and non-tiered long-context pricing.
+
+Verification results:
+- bun test src/agents/costing.test.ts -> PASS (16 pass, 0 fail)
+- lsp_diagnostics src/agents/costing.ts -> clean
+- lsp_diagnostics src/agents/costing.test.ts -> clean
+- bun run typecheck -> PASS
+- bun run lint -> PASS (repo has existing warnings only; no lint errors)
+- bun test -> PASS (158 pass, 0 fail)
+- bun run build -> PASS
+
+Notable behavior checks:
+- Mixed stream pricing now equals base bucket cost + long-context bucket cost.
+- If pricing has no longContext* fields, long-context tokens are priced at base rates.
+- Windowed costs are derived per bucket: base ratios use totalTokens, long-context ratios use longContextTotalTokens.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,6 +259,15 @@ Display estimated costs with `~` indicator: `~$0.0234`
 - PR required for all changes
 - CI must pass before merge
 
+### Commit Message Rules (MANDATORY)
+
+Commit messages must be clean and professional. **NEVER** add:
+- `Co-authored-by: Sisyphus` or any AI agent co-author trailer
+- `Ultraworked with [Sisyphus]` or any AI attribution footer
+- Any `Co-authored-by:` trailer referencing an AI tool or agent
+
+Subject line + optional body only. No AI footers. No tool attribution.
+
 ### Green CI (MANDATORY)
 
 **Every PR must have green CI before requesting review.** This means:

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@tokentop/agent-cursor": "^1.2.0",
         "@tokentop/agent-gemini": "^1.0.0",
         "@tokentop/agent-opencode": "^1.0.0",
-        "@tokentop/plugin-sdk": "^1.4.0",
+        "@tokentop/plugin-sdk": "1.5.0",
         "react": "^19.0.0",
         "react-devtools-core": "^7.0.1",
         "zod": "^4.0.0",
@@ -132,7 +132,7 @@
 
     "@tokentop/agent-opencode": ["@tokentop/agent-opencode@1.0.0", "", { "peerDependencies": { "@tokentop/plugin-sdk": "^1.0.0" } }, "sha512-2Y/1sBULn+VHnQDdVqaWLOTiTCEN5OGPWkZ3C+njmdJVfgAEZ6tL6rV8iFxZvWITV5gr845WV+3m1jZEy/dffw=="],
 
-    "@tokentop/plugin-sdk": ["@tokentop/plugin-sdk@1.4.0", "", {}, "sha512-gPuSUrZCutQB0FY2Yn/6zfl4BMHd83zJ2IyAIOGJJ8AGMvI3k++KhaYp3U5Cw7kepK8lCPOGp9RnvPji014DVg=="],
+    "@tokentop/plugin-sdk": ["@tokentop/plugin-sdk@1.5.0", "", {}, "sha512-JzFVoq0rT8HNK+66ZkXiidqaAK+0MbLpsDqcOF2U17osuuoAK9I+WPFSRG0TJDCLiCymeJLuHQdfCARHGTDPzw=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@tokentop/agent-cursor": "^1.2.0",
     "@tokentop/agent-gemini": "^1.0.0",
     "@tokentop/agent-opencode": "^1.0.0",
-    "@tokentop/plugin-sdk": "^1.4.0",
+    "@tokentop/plugin-sdk": "^1.5.0",
     "react": "^19.0.0",
     "react-devtools-core": "^7.0.1",
     "zod": "^4.0.0"

--- a/src/agents/aggregator.test.ts
+++ b/src/agents/aggregator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { SessionUsageData } from "@tokentop/plugin-sdk";
 import { aggregateSessionUsage, deduplicateAggregates } from "./aggregator.ts";
 import type { AgentSessionAggregate } from "./types.ts";
 
@@ -201,7 +202,40 @@ describe("deduplicateAggregates", () => {
 // aggregateSessionUsage — basic sanity
 // ---------------------------------------------------------------------------
 describe("aggregateSessionUsage", () => {
-  const NOW = Date.now();
+  const NOW = new Date(2026, 3, 15, 12, 0, 0, 0).getTime();
+
+  function makeUsageRow(
+    overrides: Partial<SessionUsageData> &
+      Pick<SessionUsageData, "sessionId" | "tokens" | "timestamp">,
+  ): SessionUsageData {
+    return {
+      providerId: "anthropic",
+      modelId: "claude-sonnet-4",
+      ...overrides,
+    };
+  }
+
+  function aggregateSingleSession(rows: SessionUsageData[]) {
+    const result = aggregateSessionUsage({
+      agentId: "test",
+      agentName: "Test",
+      now: NOW,
+      rows,
+    });
+
+    expect(result).toHaveLength(1);
+    return result[0]!;
+  }
+
+  function getOnlyStream(rows: SessionUsageData[]) {
+    const session = aggregateSingleSession(rows);
+    expect(session.streams).toHaveLength(1);
+    return {
+      session,
+      stream: session.streams[0]!,
+      windowed: session._streamWindowedTokens?.get("anthropic::claude-sonnet-4"),
+    };
+  }
 
   test("groups rows by sessionId", () => {
     const result = aggregateSessionUsage({
@@ -302,5 +336,239 @@ describe("aggregateSessionUsage", () => {
     const idle = result.find((r) => r.sessionId === "idle");
     expect(active!.status).toBe("active");
     expect(idle!.status).toBe("idle");
+  });
+
+  test("keeps all requests in the base bucket when every request is at or under 200K context", () => {
+    const { stream, session, windowed } = getOnlyStream([
+      makeUsageRow({ sessionId: "s1", timestamp: NOW, tokens: { input: 120_000, output: 1_000 } }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 1_000,
+        tokens: { input: 80_000, output: 2_000 },
+      }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 2_000,
+        tokens: { input: 200_000, output: 3_000 },
+      }),
+    ]);
+
+    expect(stream.tokens).toEqual({ input: 400_000, output: 6_000 });
+    expect(stream.longContextTokens).toBeUndefined();
+    expect(stream.longContextRequestCount).toBeUndefined();
+    expect(stream.hasLongContext).toBeUndefined();
+    expect(session.totals).toEqual({ input: 400_000, output: 6_000 });
+    expect(windowed).toEqual({
+      dayTokens: 406_000,
+      weekTokens: 406_000,
+      monthTokens: 406_000,
+      totalTokens: 406_000,
+    });
+  });
+
+  test("moves all requests into long-context bucket when every request exceeds 200K context", () => {
+    const { stream, windowed } = getOnlyStream([
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW,
+        tokens: { input: 210_000, output: 1_000, cacheRead: 5_000, cacheWrite: 2_000 },
+      }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 1_000,
+        tokens: { input: 220_000, output: 2_000, cacheRead: 10_000, cacheWrite: 4_000 },
+      }),
+    ]);
+
+    expect(stream.tokens).toEqual({ input: 0, output: 0 });
+    expect(stream.requestCount).toBe(2);
+    expect(stream.longContextTokens).toEqual({
+      input: 430_000,
+      output: 3_000,
+      cacheRead: 15_000,
+      cacheWrite: 6_000,
+    });
+    expect(stream.longContextRequestCount).toBe(2);
+    expect(stream.hasLongContext).toBe(true);
+    expect(windowed).toEqual({
+      dayTokens: 454_000,
+      weekTokens: 454_000,
+      monthTokens: 454_000,
+      totalTokens: 454_000,
+      longContextDayTokens: 454_000,
+      longContextWeekTokens: 454_000,
+      longContextMonthTokens: 454_000,
+      longContextTotalTokens: 454_000,
+    });
+  });
+
+  test("splits mixed requests into base and long-context buckets", () => {
+    const { stream } = getOnlyStream([
+      makeUsageRow({ sessionId: "s1", timestamp: NOW, tokens: { input: 100_000, output: 1_000 } }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 1_000,
+        tokens: { input: 120_000, output: 2_000 },
+      }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 2_000,
+        tokens: { input: 180_000, output: 3_000 },
+      }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 3_000,
+        tokens: { input: 210_000, output: 4_000 },
+      }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 4_000,
+        tokens: { input: 190_000, output: 5_000, cacheRead: 20_000 },
+      }),
+    ]);
+
+    expect(stream.tokens).toEqual({ input: 400_000, output: 6_000 });
+    expect(stream.longContextTokens).toEqual({ input: 400_000, output: 9_000, cacheRead: 20_000 });
+    expect(stream.requestCount).toBe(5);
+    expect(stream.longContextRequestCount).toBe(2);
+    expect(stream.hasLongContext).toBe(true);
+  });
+
+  test("treats exactly 200,000 context tokens as base bucket", () => {
+    const { stream, windowed } = getOnlyStream([
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW,
+        tokens: { input: 150_000, output: 7_000, cacheRead: 30_000, cacheWrite: 20_000 },
+      }),
+    ]);
+
+    expect(stream.tokens).toEqual({
+      input: 150_000,
+      output: 7_000,
+      cacheRead: 30_000,
+      cacheWrite: 20_000,
+    });
+    expect(stream.longContextTokens).toBeUndefined();
+    expect(stream.longContextRequestCount).toBeUndefined();
+    expect(stream.hasLongContext).toBeUndefined();
+    expect(windowed?.longContextTotalTokens).toBeUndefined();
+  });
+
+  test("moves 200,001 context tokens into long-context bucket", () => {
+    const { stream, windowed } = getOnlyStream([
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW,
+        tokens: { input: 150_000, output: 7_000, cacheRead: 30_001, cacheWrite: 20_000 },
+      }),
+    ]);
+
+    expect(stream.tokens).toEqual({ input: 0, output: 0 });
+    expect(stream.longContextTokens).toEqual({
+      input: 150_000,
+      output: 7_000,
+      cacheRead: 30_001,
+      cacheWrite: 20_000,
+    });
+    expect(stream.longContextRequestCount).toBe(1);
+    expect(stream.hasLongContext).toBe(true);
+    expect(windowed?.longContextTotalTokens).toBe(207_001);
+  });
+
+  test("uses cache tokens when cache-only growth crosses the threshold", () => {
+    const { stream } = getOnlyStream([
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW,
+        tokens: { input: 50_000, output: 1_000, cacheRead: 180_000 },
+      }),
+    ]);
+
+    expect(stream.tokens).toEqual({ input: 0, output: 0 });
+    expect(stream.longContextTokens).toEqual({ input: 50_000, output: 1_000, cacheRead: 180_000 });
+    expect(stream.longContextRequestCount).toBe(1);
+  });
+
+  test("treats missing cacheRead and cacheWrite as zero when computing context size", () => {
+    const { stream } = getOnlyStream([
+      makeUsageRow({ sessionId: "s1", timestamp: NOW, tokens: { input: 199_999, output: 1_000 } }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 1_000,
+        tokens: { input: 200_001, output: 2_000 },
+      }),
+    ]);
+
+    expect(stream.tokens).toEqual({ input: 199_999, output: 1_000 });
+    expect(stream.longContextTokens).toEqual({ input: 200_001, output: 2_000 });
+    expect(stream.longContextRequestCount).toBe(1);
+  });
+
+  test("splits windowed tokens correctly between total and long-context buckets", () => {
+    const { windowed } = getOnlyStream([
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 1_000,
+        tokens: { input: 210_000, output: 1_000 },
+      }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 60 * 60 * 1000,
+        tokens: { input: 90_000, output: 2_000 },
+      }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 2 * 24 * 60 * 60 * 1000,
+        tokens: { input: 205_000, output: 3_000 },
+      }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 10 * 24 * 60 * 60 * 1000,
+        tokens: { input: 80_000, output: 4_000 },
+      }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: new Date(
+          new Date(NOW).getFullYear(),
+          new Date(NOW).getMonth() - 1,
+          15,
+        ).getTime(),
+        tokens: { input: 220_000, output: 5_000 },
+      }),
+    ]);
+
+    expect(windowed).toEqual({
+      dayTokens: 303_000,
+      weekTokens: 511_000,
+      monthTokens: 595_000,
+      totalTokens: 820_000,
+      longContextDayTokens: 211_000,
+      longContextWeekTokens: 419_000,
+      longContextMonthTokens: 419_000,
+      longContextTotalTokens: 644_000,
+    });
+  });
+
+  test("does not produce division-by-zero or NaN artifacts when every request is long-context", () => {
+    const { stream, session, windowed } = getOnlyStream([
+      makeUsageRow({ sessionId: "s1", timestamp: NOW, tokens: { input: 300_000, output: 5_000 } }),
+      makeUsageRow({
+        sessionId: "s1",
+        timestamp: NOW - 1_000,
+        tokens: { input: 250_000, output: 6_000 },
+      }),
+    ]);
+
+    expect(stream.tokens).toEqual({ input: 0, output: 0 });
+    expect(stream.longContextTokens).toEqual({ input: 550_000, output: 11_000 });
+    expect(stream.longContextRequestCount).toBe(2);
+    expect(stream.hasLongContext).toBe(true);
+    expect(Number.isNaN(stream.tokens.input)).toBe(false);
+    expect(Number.isNaN(stream.tokens.output)).toBe(false);
+    expect(Number.isNaN(session.totals.input)).toBe(false);
+    expect(Number.isNaN(session.totals.output)).toBe(false);
+    expect(Number.isNaN(windowed!.totalTokens)).toBe(false);
+    expect(Number.isNaN(windowed!.longContextTotalTokens!)).toBe(false);
   });
 });

--- a/src/agents/aggregator.ts
+++ b/src/agents/aggregator.ts
@@ -1,4 +1,5 @@
 import type { SessionUsageData } from "@tokentop/plugin-sdk";
+import { LONG_CONTEXT_THRESHOLD } from "../pricing/estimator.ts";
 import {
   type AgentId,
   type AgentName,
@@ -64,7 +65,33 @@ interface StreamAccumulator {
   key: StreamKey;
   tokens: TokenCounts;
   requestCount: number;
+  longContextTokens?: TokenCounts;
+  longContextRequestCount?: number;
   windowed: StreamWindowedTokens;
+}
+
+function zeroTokens(): TokenCounts {
+  return { input: 0, output: 0 };
+}
+
+function normalizeTokens(tokens: TokenCounts): TokenCounts {
+  const normalized: TokenCounts = {
+    input: tokens.input,
+    output: tokens.output,
+  };
+
+  const cacheRead = tokens.cacheRead ?? 0;
+  const cacheWrite = tokens.cacheWrite ?? 0;
+
+  if (cacheRead > 0) normalized.cacheRead = cacheRead;
+  if (cacheWrite > 0) normalized.cacheWrite = cacheWrite;
+
+  return normalized;
+}
+
+function getContextSize(tokens: TokenCounts): number {
+  // contextSize = input + cacheRead + cacheWrite — the full prompt context sent to the model
+  return tokens.input + (tokens.cacheRead ?? 0) + (tokens.cacheWrite ?? 0);
 }
 
 export function aggregateSessionUsage(options: AggregateOptions): AgentSessionAggregate[] {
@@ -134,21 +161,52 @@ export function aggregateSessionUsage(options: AggregateOptions): AgentSessionAg
     if (!stream) {
       stream = {
         key: streamKey,
-        tokens: { input: 0, output: 0 },
+        tokens: zeroTokens(),
         requestCount: 0,
         windowed: { dayTokens: 0, weekTokens: 0, monthTokens: 0, totalTokens: 0 },
       };
       session.streamMap.set(streamKeyStr, stream);
     }
 
-    stream.tokens = sumTokens(stream.tokens, row.tokens);
+    const contextSize = getContextSize(row.tokens);
+    const bucketTokens = normalizeTokens(row.tokens);
+
+    if (contextSize > LONG_CONTEXT_THRESHOLD) {
+      stream.longContextTokens = sumTokens(stream.longContextTokens ?? zeroTokens(), bucketTokens);
+      stream.longContextRequestCount = (stream.longContextRequestCount ?? 0) + 1;
+    } else {
+      stream.tokens = sumTokens(stream.tokens, bucketTokens);
+    }
+
     stream.requestCount += 1;
 
     const msgTokens = totalTokenCount(row.tokens);
     stream.windowed.totalTokens += msgTokens;
-    if (row.timestamp >= startOfDay) stream.windowed.dayTokens += msgTokens;
-    if (row.timestamp >= startOfWeek) stream.windowed.weekTokens += msgTokens;
-    if (row.timestamp >= startOfMonth) stream.windowed.monthTokens += msgTokens;
+    if (contextSize > LONG_CONTEXT_THRESHOLD) {
+      stream.windowed.longContextTotalTokens =
+        (stream.windowed.longContextTotalTokens ?? 0) + msgTokens;
+    }
+    if (row.timestamp >= startOfDay) {
+      stream.windowed.dayTokens += msgTokens;
+      if (contextSize > LONG_CONTEXT_THRESHOLD) {
+        stream.windowed.longContextDayTokens =
+          (stream.windowed.longContextDayTokens ?? 0) + msgTokens;
+      }
+    }
+    if (row.timestamp >= startOfWeek) {
+      stream.windowed.weekTokens += msgTokens;
+      if (contextSize > LONG_CONTEXT_THRESHOLD) {
+        stream.windowed.longContextWeekTokens =
+          (stream.windowed.longContextWeekTokens ?? 0) + msgTokens;
+      }
+    }
+    if (row.timestamp >= startOfMonth) {
+      stream.windowed.monthTokens += msgTokens;
+      if (contextSize > LONG_CONTEXT_THRESHOLD) {
+        stream.windowed.longContextMonthTokens =
+          (stream.windowed.longContextMonthTokens ?? 0) + msgTokens;
+      }
+    }
     if ((row.metadata?.isEstimated as boolean) === true) {
       session.hasEstimated = true;
     }
@@ -168,13 +226,24 @@ export function aggregateSessionUsage(options: AggregateOptions): AgentSessionAg
     let totalRequestCount = 0;
 
     for (const [streamKeyStr, stream] of session.streamMap) {
-      streams.push({
+      const totalStreamTokens = sumTokens(stream.tokens, stream.longContextTokens ?? zeroTokens());
+      const streamAggregate: AgentSessionStream = {
         providerId: stream.key.providerId,
         modelId: stream.key.modelId,
         tokens: stream.tokens,
         requestCount: stream.requestCount,
-      });
-      totals = sumTokens(totals, stream.tokens);
+      };
+
+      if (stream.longContextTokens) {
+        streamAggregate.longContextTokens = stream.longContextTokens;
+      }
+      if (stream.longContextRequestCount) {
+        streamAggregate.longContextRequestCount = stream.longContextRequestCount;
+        streamAggregate.hasLongContext = true;
+      }
+
+      streams.push(streamAggregate);
+      totals = sumTokens(totals, totalStreamTokens);
       totalRequestCount += stream.requestCount;
       streamWindowedTokens.set(streamKeyStr, stream.windowed);
     }

--- a/src/agents/costing.test.ts
+++ b/src/agents/costing.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ModelPricing } from "@tokentop/plugin-sdk";
+import { estimateCost } from "@/pricing/estimator.ts";
+import type { AgentSessionAggregate, AgentSessionStream } from "./types.ts";
+
+const getPricing = mock<(providerId: string, modelId: string) => Promise<ModelPricing | null>>(
+  async () => null,
+);
+
+mock.module("@/pricing/index.ts", () => ({
+  estimateCost,
+  getPricing,
+}));
+
+const { priceSession, priceSessions, priceStream } = await import("./costing.ts");
+
+function makeStream(overrides: Partial<AgentSessionStream> = {}): AgentSessionStream {
+  return {
+    providerId: "anthropic",
+    modelId: "claude-sonnet-4",
+    tokens: { input: 0, output: 0 },
+    requestCount: 1,
+    ...overrides,
+  };
+}
+
+function makeSession(
+  overrides: Partial<AgentSessionAggregate> & Pick<AgentSessionAggregate, "sessionId">,
+): AgentSessionAggregate {
+  return {
+    agentId: "opencode",
+    agentName: "OpenCode",
+    startedAt: 0,
+    lastActivityAt: 0,
+    status: "idle",
+    totals: { input: 0, output: 0 },
+    requestCount: 0,
+    streams: [],
+    costInDay: 0,
+    costInWeek: 0,
+    costInMonth: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  getPricing.mockReset();
+  getPricing.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  getPricing.mockClear();
+});
+
+describe("priceStream()", () => {
+  test("prices a single stream with fallback pricing and cache breakdown", async () => {
+    getPricing.mockResolvedValue({
+      input: 2,
+      output: 4,
+      cacheRead: 1,
+      cacheWrite: 3,
+      source: "fallback",
+    });
+
+    const priced = await priceStream(
+      makeStream({
+        tokens: { input: 500_000, output: 250_000, cacheRead: 100_000, cacheWrite: 50_000 },
+      }),
+    );
+
+    expect(getPricing).toHaveBeenCalledWith("anthropic", "claude-sonnet-4");
+    expect(priced).toMatchObject({
+      costUsd: 2.25,
+      costBreakdown: {
+        total: 2.25,
+        input: 1,
+        output: 1,
+        cacheRead: 0.1,
+        cacheWrite: 0.15,
+      },
+      pricingSource: "fallback",
+    });
+  });
+
+  test("marks priced streams as models.dev when pricing comes from models.dev", async () => {
+    getPricing.mockResolvedValue({
+      input: 1.5,
+      output: 6,
+      source: "models.dev",
+    });
+
+    const priced = await priceStream(
+      makeStream({
+        providerId: "openai",
+        modelId: "gpt-4.1",
+        tokens: { input: 200_000, output: 300_000 },
+      }),
+    );
+
+    expect(priced.costUsd).toBe(2.1);
+    expect(priced.costBreakdown).toEqual({
+      total: 2.1,
+      input: 0.3,
+      output: 1.8,
+    });
+    expect(priced.pricingSource).toBe("models.dev");
+  });
+
+  test("returns unknown pricing source when no pricing is available", async () => {
+    const stream = makeStream({ tokens: { input: 123, output: 456 } });
+
+    await expect(priceStream(stream)).resolves.toEqual({
+      ...stream,
+      pricingSource: "unknown",
+    });
+  });
+});
+
+describe("priceSession()", () => {
+  test("prices a multi-stream session and removes internal window metadata", async () => {
+    getPricing.mockImplementation(async (providerId, modelId) => {
+      if (`${providerId}::${modelId}` === "anthropic::claude-sonnet-4") {
+        return { input: 2, output: 4, cacheRead: 1, cacheWrite: 3, source: "fallback" };
+      }
+
+      if (`${providerId}::${modelId}` === "openai::gpt-4.1") {
+        return { input: 1.5, output: 6, source: "models.dev" };
+      }
+
+      return null;
+    });
+
+    const priced = await priceSession(
+      makeSession({
+        sessionId: "multi-stream",
+        requestCount: 3,
+        streams: [
+          makeStream({
+            tokens: { input: 500_000, output: 250_000, cacheRead: 100_000, cacheWrite: 50_000 },
+            requestCount: 2,
+          }),
+          makeStream({
+            providerId: "openai",
+            modelId: "gpt-4.1",
+            tokens: { input: 200_000, output: 300_000 },
+            requestCount: 1,
+          }),
+        ],
+        _streamWindowedTokens: new Map([
+          [
+            "anthropic::claude-sonnet-4",
+            { dayTokens: 400, weekTokens: 500, monthTokens: 750, totalTokens: 1000 },
+          ],
+          [
+            "openai::gpt-4.1",
+            { dayTokens: 1000, weekTokens: 1200, monthTokens: 1500, totalTokens: 2000 },
+          ],
+        ]),
+      }),
+    );
+
+    expect(priced.totalCostUsd).toBe(4.35);
+    expect(priced.costInDay).toBeCloseTo(1.95, 10);
+    expect(priced.costInWeek).toBeCloseTo(2.385, 10);
+    expect(priced.costInMonth).toBeCloseTo(3.2625, 10);
+    expect(priced.streams.map((stream) => stream.pricingSource)).toEqual([
+      "fallback",
+      "models.dev",
+    ]);
+    expect(priced).not.toHaveProperty("_streamWindowedTokens");
+  });
+
+  test("uses the current windowed cost ratio formula for day, week, and month costs", async () => {
+    getPricing.mockResolvedValue({ input: 10, output: 0, source: "fallback" });
+
+    const priced = await priceSession(
+      makeSession({
+        sessionId: "ratio",
+        streams: [makeStream({ tokens: { input: 1_000_000, output: 0 } })],
+        _streamWindowedTokens: new Map([
+          [
+            "anthropic::claude-sonnet-4",
+            { dayTokens: 500, weekTokens: 750, monthTokens: 1000, totalTokens: 1000 },
+          ],
+        ]),
+      }),
+    );
+
+    expect(priced.totalCostUsd).toBe(10);
+    expect(priced.costInDay).toBe(5);
+    expect(priced.costInWeek).toBe(7.5);
+    expect(priced.costInMonth).toBe(10);
+  });
+
+  test("returns zero costs for zero-token streams without dividing by zero", async () => {
+    getPricing.mockResolvedValue({ input: 3, output: 15, source: "fallback" });
+
+    const priced = await priceSession(
+      makeSession({
+        sessionId: "zero-token",
+        streams: [makeStream({ tokens: { input: 0, output: 0 }, requestCount: 0 })],
+        _streamWindowedTokens: new Map([
+          [
+            "anthropic::claude-sonnet-4",
+            { dayTokens: 0, weekTokens: 0, monthTokens: 0, totalTokens: 0 },
+          ],
+        ]),
+      }),
+    );
+
+    expect(priced.totalCostUsd).toBe(0);
+    expect(priced.costInDay).toBe(0);
+    expect(priced.costInWeek).toBe(0);
+    expect(priced.costInMonth).toBe(0);
+    expect(priced.streams[0]).toMatchObject({
+      costUsd: 0,
+      costBreakdown: { total: 0, input: 0, output: 0 },
+      pricingSource: "fallback",
+    });
+  });
+
+  test("returns an empty session unchanged when there are no streams", async () => {
+    const priced = await priceSession(makeSession({ sessionId: "empty" }));
+
+    expect(priced.streams).toEqual([]);
+    expect(priced.totalCostUsd).toBeUndefined();
+    expect(priced.costInDay).toBe(0);
+    expect(priced.costInWeek).toBe(0);
+    expect(priced.costInMonth).toBe(0);
+  });
+
+  test("ignores windowed allocations for streams without pricing", async () => {
+    getPricing.mockResolvedValue(null);
+
+    const priced = await priceSession(
+      makeSession({
+        sessionId: "unknown-pricing",
+        streams: [makeStream({ tokens: { input: 1_000_000, output: 500_000 } })],
+        _streamWindowedTokens: new Map([
+          [
+            "anthropic::claude-sonnet-4",
+            { dayTokens: 500, weekTokens: 800, monthTokens: 1000, totalTokens: 1000 },
+          ],
+        ]),
+      }),
+    );
+
+    expect(priced.totalCostUsd).toBeUndefined();
+    expect(priced.costInDay).toBe(0);
+    expect(priced.costInWeek).toBe(0);
+    expect(priced.costInMonth).toBe(0);
+    expect(priced.streams[0]?.pricingSource).toBe("unknown");
+  });
+});
+
+describe("priceSessions()", () => {
+  test("prices sessions in a batch", async () => {
+    getPricing.mockImplementation(async (providerId, modelId) => {
+      if (`${providerId}::${modelId}` === "anthropic::claude-sonnet-4") {
+        return { input: 2, output: 4, source: "fallback" };
+      }
+
+      if (`${providerId}::${modelId}` === "openai::gpt-4.1") {
+        return { input: 1, output: 2, source: "fallback" };
+      }
+
+      return null;
+    });
+
+    const priced = await priceSessions([
+      makeSession({
+        sessionId: "batch-a",
+        streams: [makeStream({ tokens: { input: 500_000, output: 250_000 } })],
+      }),
+      makeSession({
+        sessionId: "batch-b",
+        streams: [
+          makeStream({
+            providerId: "openai",
+            modelId: "gpt-4.1",
+            tokens: { input: 1_000_000, output: 500_000 },
+          }),
+        ],
+      }),
+    ]);
+
+    expect(priced).toHaveLength(2);
+    expect(
+      priced.map((session) => ({
+        sessionId: session.sessionId,
+        totalCostUsd: session.totalCostUsd,
+      })),
+    ).toEqual([
+      { sessionId: "batch-a", totalCostUsd: 2 },
+      { sessionId: "batch-b", totalCostUsd: 2 },
+    ]);
+  });
+});

--- a/src/agents/costing.test.ts
+++ b/src/agents/costing.test.ts
@@ -106,13 +106,178 @@ describe("priceStream()", () => {
     expect(priced.pricingSource).toBe("models.dev");
   });
 
-  test("returns unknown pricing source when no pricing is available", async () => {
+  test("returns unknown pricing source when no pricing is available", () => {
     const stream = makeStream({ tokens: { input: 123, output: 456 } });
 
-    await expect(priceStream(stream)).resolves.toEqual({
+    return expect(priceStream(stream)).resolves.toEqual({
       ...stream,
       pricingSource: "unknown",
     });
+  });
+
+  test("keeps base-only pricing identical when tiered pricing metadata exists", async () => {
+    getPricing.mockResolvedValue({
+      input: 2,
+      output: 4,
+      cacheRead: 1,
+      cacheWrite: 3,
+      longContextInput: 20,
+      longContextOutput: 40,
+      longContextCacheRead: 10,
+      longContextCacheWrite: 30,
+      source: "fallback",
+    });
+
+    const priced = await priceStream(
+      makeStream({
+        tokens: { input: 500_000, output: 250_000, cacheRead: 100_000, cacheWrite: 50_000 },
+      }),
+    );
+
+    expect(priced.costUsd).toBe(2.25);
+    expect(priced.costBreakdown).toEqual({
+      total: 2.25,
+      input: 1,
+      output: 1,
+      cacheRead: 0.1,
+      cacheWrite: 0.15,
+    });
+    expect(priced.hasLongContext).toBeUndefined();
+  });
+
+  test("applies long-context tiered pricing to a long-context-only stream", async () => {
+    getPricing.mockResolvedValue({
+      input: 2,
+      output: 4,
+      cacheRead: 1,
+      cacheWrite: 3,
+      longContextInput: 4,
+      longContextOutput: 8,
+      longContextCacheRead: 2,
+      longContextCacheWrite: 6,
+      source: "models.dev",
+    });
+
+    const priced = await priceStream(
+      makeStream({
+        tokens: { input: 0, output: 0 },
+        longContextTokens: {
+          input: 200_000,
+          output: 100_000,
+          cacheRead: 50_000,
+          cacheWrite: 25_000,
+        },
+        longContextRequestCount: 1,
+      }),
+    );
+
+    expect(priced.costUsd).toBe(1.85);
+    expect(priced.costBreakdown).toEqual({
+      total: 1.85,
+      input: 0.8,
+      output: 0.8,
+      cacheRead: 0.1,
+      cacheWrite: 0.15,
+    });
+    expect(priced.hasLongContext).toBe(true);
+    expect(priced.pricingSource).toBe("models.dev");
+  });
+
+  test("sums base and long-context buckets for mixed streams", async () => {
+    getPricing.mockResolvedValue({
+      input: 3,
+      output: 9,
+      cacheRead: 1,
+      cacheWrite: 4,
+      longContextInput: 6,
+      longContextOutput: 18,
+      longContextCacheRead: 2,
+      longContextCacheWrite: 8,
+      source: "fallback",
+    });
+
+    const priced = await priceStream(
+      makeStream({
+        tokens: { input: 100_000, output: 50_000, cacheRead: 10_000, cacheWrite: 5_000 },
+        longContextTokens: {
+          input: 250_000,
+          output: 100_000,
+          cacheRead: 50_000,
+          cacheWrite: 25_000,
+        },
+        longContextRequestCount: 2,
+      }),
+    );
+
+    expect(priced.costUsd).toBe(4.38);
+    expect(priced.costBreakdown).toEqual({
+      total: 4.38,
+      input: 1.8,
+      output: 2.25,
+      cacheRead: 0.11,
+      cacheWrite: 0.22,
+    });
+    expect(priced.hasLongContext).toBe(true);
+  });
+
+  test("uses base pricing conservatively when long-context pricing is unavailable", async () => {
+    getPricing.mockResolvedValue({
+      input: 2,
+      output: 6,
+      cacheRead: 1,
+      cacheWrite: 3,
+      source: "fallback",
+    });
+
+    const priced = await priceStream(
+      makeStream({
+        tokens: { input: 100_000, output: 50_000, cacheRead: 20_000, cacheWrite: 10_000 },
+        longContextTokens: {
+          input: 250_000,
+          output: 100_000,
+          cacheRead: 80_000,
+          cacheWrite: 40_000,
+        },
+        longContextRequestCount: 1,
+      }),
+    );
+
+    expect(priced.costUsd).toBe(1.85);
+    expect(priced.costBreakdown).toEqual({
+      total: 1.85,
+      input: 0.7,
+      output: 0.9,
+      cacheRead: 0.1,
+      cacheWrite: 0.15,
+    });
+    expect(priced.hasLongContext).toBe(true);
+  });
+
+  test("handles empty long-context buckets without NaN or errors", async () => {
+    getPricing.mockResolvedValue({
+      input: 2,
+      output: 4,
+      longContextInput: 6,
+      longContextOutput: 12,
+      source: "fallback",
+    });
+
+    const priced = await priceStream(
+      makeStream({
+        tokens: { input: 300_000, output: 100_000 },
+        longContextTokens: { input: 0, output: 0 },
+        longContextRequestCount: 1,
+      }),
+    );
+
+    expect(priced.costUsd).toBe(1);
+    expect(priced.costBreakdown).toEqual({
+      total: 1,
+      input: 0.6,
+      output: 0.4,
+    });
+    expect(Number.isNaN(priced.costUsd ?? 0)).toBe(false);
+    expect(priced.hasLongContext).toBe(true);
   });
 });
 
@@ -250,6 +415,127 @@ describe("priceSession()", () => {
     expect(priced.costInWeek).toBe(0);
     expect(priced.costInMonth).toBe(0);
     expect(priced.streams[0]?.pricingSource).toBe("unknown");
+  });
+
+  test("prices windowed costs with per-bucket ratios instead of a blended ratio", async () => {
+    getPricing.mockResolvedValue({
+      input: 2,
+      output: 0,
+      longContextInput: 6,
+      longContextOutput: 0,
+      source: "fallback",
+    });
+
+    const priced = await priceSession(
+      makeSession({
+        sessionId: "windowed-buckets",
+        streams: [
+          makeStream({
+            tokens: { input: 1_000_000, output: 0 },
+            longContextTokens: { input: 1_000_000, output: 0 },
+            longContextRequestCount: 1,
+          }),
+        ],
+        _streamWindowedTokens: new Map([
+          [
+            "anthropic::claude-sonnet-4",
+            {
+              dayTokens: 1_000_000,
+              weekTokens: 500_000,
+              monthTokens: 1_000_000,
+              totalTokens: 1_000_000,
+              longContextDayTokens: 0,
+              longContextWeekTokens: 250_000,
+              longContextMonthTokens: 1_000_000,
+              longContextTotalTokens: 1_000_000,
+            },
+          ],
+        ]),
+      }),
+    );
+
+    expect(priced.totalCostUsd).toBe(8);
+    expect(priced.costInDay).toBe(2);
+    expect(priced.costInWeek).toBe(2.5);
+    expect(priced.costInMonth).toBe(8);
+  });
+
+  test("prices multi-stream sessions with mixed tiered and non-tiered long-context streams", async () => {
+    getPricing.mockImplementation(async (providerId, modelId) => {
+      if (`${providerId}::${modelId}` === "anthropic::claude-sonnet-4") {
+        return {
+          input: 2,
+          output: 0,
+          longContextInput: 6,
+          longContextOutput: 0,
+          source: "fallback",
+        };
+      }
+
+      if (`${providerId}::${modelId}` === "openai::gpt-4.1") {
+        return {
+          input: 4,
+          output: 0,
+          source: "fallback",
+        };
+      }
+
+      return null;
+    });
+
+    const priced = await priceSession(
+      makeSession({
+        sessionId: "mixed-tiered-session",
+        streams: [
+          makeStream({
+            tokens: { input: 500_000, output: 0 },
+            longContextTokens: { input: 250_000, output: 0 },
+            longContextRequestCount: 1,
+          }),
+          makeStream({
+            providerId: "openai",
+            modelId: "gpt-4.1",
+            tokens: { input: 500_000, output: 0 },
+            longContextTokens: { input: 250_000, output: 0 },
+            longContextRequestCount: 1,
+          }),
+        ],
+        _streamWindowedTokens: new Map([
+          [
+            "anthropic::claude-sonnet-4",
+            {
+              dayTokens: 250_000,
+              weekTokens: 500_000,
+              monthTokens: 500_000,
+              totalTokens: 500_000,
+              longContextDayTokens: 50_000,
+              longContextWeekTokens: 100_000,
+              longContextMonthTokens: 250_000,
+              longContextTotalTokens: 250_000,
+            },
+          ],
+          [
+            "openai::gpt-4.1",
+            {
+              dayTokens: 100_000,
+              weekTokens: 250_000,
+              monthTokens: 500_000,
+              totalTokens: 500_000,
+              longContextDayTokens: 125_000,
+              longContextWeekTokens: 125_000,
+              longContextMonthTokens: 250_000,
+              longContextTotalTokens: 250_000,
+            },
+          ],
+        ]),
+      }),
+    );
+
+    expect(priced.totalCostUsd).toBe(5.5);
+    expect(priced.costInDay).toBe(1.7);
+    expect(priced.costInWeek).toBe(3.1);
+    expect(priced.costInMonth).toBe(5.5);
+    expect(priced.streams.map((stream) => stream.hasLongContext)).toEqual([true, true]);
   });
 });
 

--- a/src/agents/costing.ts
+++ b/src/agents/costing.ts
@@ -1,34 +1,21 @@
+import type { CostBreakdown, ModelPricing } from "@tokentop/plugin-sdk";
 import { estimateCost, getPricing } from "@/pricing/index.ts";
 import type { AgentSessionAggregate, AgentSessionStream, StreamCostBreakdown } from "./types.ts";
 
 export async function priceStream(stream: AgentSessionStream): Promise<AgentSessionStream> {
   const pricing = await getPricing(stream.providerId, stream.modelId);
 
-  if (!pricing) {
-    return { ...stream, pricingSource: "unknown" };
-  }
-
-  const breakdown = estimateCost(stream.tokens, pricing);
-  const source = pricing.source === "models.dev" ? "models.dev" : "fallback";
-
-  const costBreakdown: StreamCostBreakdown = {
-    total: breakdown.total,
-    input: breakdown.input ?? 0,
-    output: breakdown.output ?? 0,
-  };
-  if (breakdown.cacheRead) costBreakdown.cacheRead = breakdown.cacheRead;
-  if (breakdown.cacheWrite) costBreakdown.cacheWrite = breakdown.cacheWrite;
-
-  return {
-    ...stream,
-    costUsd: breakdown.total,
-    costBreakdown,
-    pricingSource: source,
-  };
+  return priceStreamWithPricing(stream, pricing).stream;
 }
 
 export async function priceSession(session: AgentSessionAggregate): Promise<AgentSessionAggregate> {
-  const pricedStreams = await Promise.all(session.streams.map(priceStream));
+  const pricedResults = await Promise.all(
+    session.streams.map(async (stream) => {
+      const pricing = await getPricing(stream.providerId, stream.modelId);
+      return priceStreamWithPricing(stream, pricing);
+    }),
+  );
+  const pricedStreams = pricedResults.map((result) => result.stream);
 
   const totalCostUsd = pricedStreams.reduce((sum, s) => {
     return sum + (s.costUsd ?? 0);
@@ -41,18 +28,37 @@ export async function priceSession(session: AgentSessionAggregate): Promise<Agen
   let costInMonth = 0;
 
   if (hasAnyCost && session._streamWindowedTokens) {
-    for (const stream of pricedStreams) {
-      const streamCost = stream.costUsd ?? 0;
+    for (const result of pricedResults) {
+      const streamCost = result.stream.costUsd ?? 0;
       if (streamCost === 0) continue;
 
-      const keyStr = `${stream.providerId}::${stream.modelId}`;
+      const keyStr = `${result.stream.providerId}::${result.stream.modelId}`;
       const windowed = session._streamWindowedTokens.get(keyStr);
-      if (!windowed || windowed.totalTokens === 0) continue;
+      if (!windowed) continue;
 
-      const ratio = 1 / windowed.totalTokens;
-      costInDay += streamCost * windowed.dayTokens * ratio;
-      costInWeek += streamCost * windowed.weekTokens * ratio;
-      costInMonth += streamCost * windowed.monthTokens * ratio;
+      if (result.baseBreakdown.total > 0 && windowed.totalTokens > 0) {
+        const baseRatio = 1 / windowed.totalTokens;
+        costInDay += result.baseBreakdown.total * windowed.dayTokens * baseRatio;
+        costInWeek += result.baseBreakdown.total * windowed.weekTokens * baseRatio;
+        costInMonth += result.baseBreakdown.total * windowed.monthTokens * baseRatio;
+      }
+
+      const longContextTotalTokens = windowed.longContextTotalTokens ?? 0;
+      if (result.longContextBreakdown.total > 0 && longContextTotalTokens > 0) {
+        const longContextRatio = 1 / longContextTotalTokens;
+        costInDay +=
+          result.longContextBreakdown.total *
+          (windowed.longContextDayTokens ?? 0) *
+          longContextRatio;
+        costInWeek +=
+          result.longContextBreakdown.total *
+          (windowed.longContextWeekTokens ?? 0) *
+          longContextRatio;
+        costInMonth +=
+          result.longContextBreakdown.total *
+          (windowed.longContextMonthTokens ?? 0) *
+          longContextRatio;
+      }
     }
   }
 
@@ -69,8 +75,116 @@ export async function priceSession(session: AgentSessionAggregate): Promise<Agen
   return result;
 }
 
+type PricedStreamResult = {
+  stream: AgentSessionStream;
+  baseBreakdown: CostBreakdown;
+  longContextBreakdown: CostBreakdown;
+};
+
+function priceStreamWithPricing(
+  stream: AgentSessionStream,
+  pricing: ModelPricing | null,
+): PricedStreamResult {
+  const hasLongContext = (stream.longContextRequestCount ?? 0) > 0;
+
+  if (!pricing) {
+    return {
+      stream: {
+        ...stream,
+        ...(hasLongContext ? { hasLongContext: true } : {}),
+        pricingSource: "unknown",
+      },
+      baseBreakdown: zeroCostBreakdown(),
+      longContextBreakdown: zeroCostBreakdown(),
+    };
+  }
+
+  const baseBreakdown = estimateCost(stream.tokens, pricing);
+  const longContextBreakdown = stream.longContextTokens
+    ? estimateCost(
+        stream.longContextTokens,
+        hasLongContextPricing(pricing) ? buildLongContextPricing(pricing) : pricing,
+      )
+    : zeroCostBreakdown();
+  const breakdown = sumCostBreakdowns(baseBreakdown, longContextBreakdown);
+  const source = pricing.source === "models.dev" ? "models.dev" : "fallback";
+
+  return {
+    stream: {
+      ...stream,
+      ...(hasLongContext ? { hasLongContext: true } : {}),
+      costUsd: breakdown.total,
+      costBreakdown: toStreamCostBreakdown(breakdown),
+      pricingSource: source,
+    },
+    baseBreakdown,
+    longContextBreakdown,
+  };
+}
+
 export async function priceSessions(
   sessions: AgentSessionAggregate[],
 ): Promise<AgentSessionAggregate[]> {
   return Promise.all(sessions.map(priceSession));
+}
+
+function hasLongContextPricing(pricing: ModelPricing): boolean {
+  return (
+    pricing.longContextInput !== undefined ||
+    pricing.longContextOutput !== undefined ||
+    pricing.longContextCacheRead !== undefined ||
+    pricing.longContextCacheWrite !== undefined
+  );
+}
+
+function buildLongContextPricing(pricing: ModelPricing): ModelPricing {
+  return {
+    ...pricing,
+    input: pricing.longContextInput ?? pricing.input,
+    output: pricing.longContextOutput ?? pricing.output,
+    ...(pricing.longContextCacheRead !== undefined || pricing.cacheRead !== undefined
+      ? { cacheRead: pricing.longContextCacheRead ?? pricing.cacheRead }
+      : {}),
+    ...(pricing.longContextCacheWrite !== undefined || pricing.cacheWrite !== undefined
+      ? { cacheWrite: pricing.longContextCacheWrite ?? pricing.cacheWrite }
+      : {}),
+  };
+}
+
+function toStreamCostBreakdown(breakdown: CostBreakdown): StreamCostBreakdown {
+  const costBreakdown: StreamCostBreakdown = {
+    total: breakdown.total,
+    input: breakdown.input ?? 0,
+    output: breakdown.output ?? 0,
+  };
+  if (breakdown.cacheRead) costBreakdown.cacheRead = breakdown.cacheRead;
+  if (breakdown.cacheWrite) costBreakdown.cacheWrite = breakdown.cacheWrite;
+  return costBreakdown;
+}
+
+function sumCostBreakdowns(a: CostBreakdown, b: CostBreakdown): CostBreakdown {
+  const cacheRead = (a.cacheRead ?? 0) + (b.cacheRead ?? 0);
+  const cacheWrite = (a.cacheWrite ?? 0) + (b.cacheWrite ?? 0);
+  const breakdown: CostBreakdown = {
+    total: roundCost(a.total + b.total),
+    input: roundCost((a.input ?? 0) + (b.input ?? 0)),
+    output: roundCost((a.output ?? 0) + (b.output ?? 0)),
+    currency: a.currency,
+  };
+  if (cacheRead > 0) breakdown.cacheRead = roundCost(cacheRead);
+  if (cacheWrite > 0) breakdown.cacheWrite = roundCost(cacheWrite);
+  return breakdown;
+}
+
+function zeroCostBreakdown(): CostBreakdown {
+  return {
+    total: 0,
+    input: 0,
+    output: 0,
+    currency: "USD",
+  };
+}
+
+function roundCost(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
 }

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -27,6 +27,9 @@ export interface AgentSessionStream {
   modelId: string;
   tokens: TokenCounts;
   requestCount: number;
+  longContextTokens?: TokenCounts;
+  longContextRequestCount?: number;
+  hasLongContext?: boolean;
   costUsd?: number;
   costBreakdown?: StreamCostBreakdown;
   pricingSource?: "models.dev" | "fallback" | "unknown";
@@ -37,6 +40,10 @@ export interface StreamWindowedTokens {
   weekTokens: number;
   monthTokens: number;
   totalTokens: number;
+  longContextDayTokens?: number;
+  longContextWeekTokens?: number;
+  longContextMonthTokens?: number;
+  longContextTotalTokens?: number;
 }
 
 export interface AgentSessionAggregate {

--- a/src/demo/simulator.ts
+++ b/src/demo/simulator.ts
@@ -1,5 +1,11 @@
 import type { ProviderUsageData } from "@tokentop/plugin-sdk";
-import type { AgentSessionAggregate, AgentSessionStream } from "@/agents/types.ts";
+import type {
+  AgentSessionAggregate,
+  AgentSessionStream,
+  StreamCostBreakdown,
+  StreamWindowedTokens,
+  TokenCounts,
+} from "@/agents/types.ts";
 import type { UsageEventInsert } from "@/storage/types.ts";
 
 /**
@@ -161,6 +167,70 @@ function hashCombine(a: number, b: number): number {
   return ((a * 2654435761) ^ (b * 1597334677)) >>> 0;
 }
 
+function roundCost(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function totalTokens(tokens: TokenCounts): number {
+  return tokens.input + (tokens.cacheRead ?? 0) + (tokens.cacheWrite ?? 0) + tokens.output;
+}
+
+function createLongContextTokens(rng: DemoRng): TokenCounts {
+  return {
+    input: 240_000 + Math.floor(rng.range(0, 40_000)),
+    output: 4_000 + Math.floor(rng.range(0, 6_000)),
+  };
+}
+
+function createStreamCostBreakdown(
+  baseCost: number,
+  inputTokens: number,
+  outputTokens: number,
+  longContextTokens?: TokenCounts,
+): { costUsd: number; costBreakdown: StreamCostBreakdown } {
+  const baseInputCost = baseCost * 0.55;
+  const baseOutputCost = baseCost - baseInputCost;
+  const inputRate = baseInputCost / (inputTokens / 1_000_000);
+  const outputRate = baseOutputCost / (outputTokens / 1_000_000);
+
+  const longContextInputCost = longContextTokens
+    ? (longContextTokens.input / 1_000_000) * inputRate * 2
+    : 0;
+  const longContextOutputCost = longContextTokens
+    ? (longContextTokens.output / 1_000_000) * outputRate * 2
+    : 0;
+  const total = baseCost + longContextInputCost + longContextOutputCost;
+
+  return {
+    costUsd: roundCost(total),
+    costBreakdown: {
+      total: roundCost(total),
+      input: roundCost(baseInputCost + longContextInputCost),
+      output: roundCost(baseOutputCost + longContextOutputCost),
+    },
+  };
+}
+
+function createWindowedTokens(
+  inputTokens: number,
+  outputTokens: number,
+  longContextTokens?: TokenCounts,
+): StreamWindowedTokens {
+  const baseTotalTokens = totalTokens({ input: inputTokens, output: outputTokens });
+  const longContextTotalTokens = longContextTokens ? totalTokens(longContextTokens) : 0;
+
+  return {
+    dayTokens: baseTotalTokens,
+    weekTokens: baseTotalTokens,
+    monthTokens: baseTotalTokens,
+    totalTokens: baseTotalTokens,
+    ...(longContextTotalTokens > 0 ? { longContextDayTokens: longContextTotalTokens } : {}),
+    ...(longContextTotalTokens > 0 ? { longContextWeekTokens: longContextTotalTokens } : {}),
+    ...(longContextTotalTokens > 0 ? { longContextMonthTokens: longContextTotalTokens } : {}),
+    ...(longContextTotalTokens > 0 ? { longContextTotalTokens } : {}),
+  };
+}
+
 class DemoRng {
   private seed: number;
   private initialSeed: number;
@@ -238,21 +308,44 @@ export class DemoSimulator {
       ...inactiveSessions.slice(0, inactiveCount),
     ];
 
+    const longContextSessionIndexes = this.pickLongContextSessionIndexes(selectedSessions);
+
     this.sessions = selectedSessions.map((seedSession, index) => {
       const tokens = seedSession.baseTokens;
-      const cost = seedSession.baseCost;
       const inputTokens = Math.floor(tokens * 0.6);
       const outputTokens = tokens - inputTokens;
-      const streams: AgentSessionStream[] = [
-        {
-          providerId: seedSession.providerId,
-          modelId: seedSession.modelId,
-          tokens: { input: inputTokens, output: outputTokens },
-          requestCount: Math.max(1, Math.floor(tokens / 800)),
-          costUsd: cost,
-          pricingSource: "fallback",
-        },
-      ];
+      const hasLongContext = longContextSessionIndexes.has(index);
+      const longContextTokens = hasLongContext
+        ? createLongContextTokens(this.rng.fork(hashCombine(index + 1, seedSession.baseTokens)))
+        : undefined;
+      const { costUsd, costBreakdown } = createStreamCostBreakdown(
+        seedSession.baseCost,
+        inputTokens,
+        outputTokens,
+        longContextTokens,
+      );
+      const streamWindowedTokens = createWindowedTokens(
+        inputTokens,
+        outputTokens,
+        longContextTokens,
+      );
+      const requestCount = Math.max(1, Math.floor(tokens / 800));
+      const longContextRequestCount = hasLongContext ? 1 : 0;
+      const stream: AgentSessionStream = {
+        providerId: seedSession.providerId,
+        modelId: seedSession.modelId,
+        tokens: { input: inputTokens, output: outputTokens },
+        requestCount: requestCount + longContextRequestCount,
+        costUsd,
+        costBreakdown,
+        pricingSource: "fallback",
+      };
+      if (hasLongContext && longContextTokens) {
+        stream.longContextTokens = longContextTokens;
+        stream.longContextRequestCount = longContextRequestCount;
+        stream.hasLongContext = true;
+      }
+      const streams: AgentSessionStream[] = [stream];
 
       const isInactive = seedSession.inactive ?? false;
       const startedAt = isInactive
@@ -276,9 +369,9 @@ export class DemoSimulator {
       ).getTime();
       const startOfMonth = new Date(nowDate.getFullYear(), nowDate.getMonth(), 1).getTime();
 
-      const costInDay = lastActivityAt >= startOfDay ? cost : 0;
-      const costInWeek = lastActivityAt >= startOfWeek ? cost : 0;
-      const costInMonth = lastActivityAt >= startOfMonth ? cost : 0;
+      const costInDay = lastActivityAt >= startOfDay ? costUsd : 0;
+      const costInWeek = lastActivityAt >= startOfWeek ? costUsd : 0;
+      const costInMonth = lastActivityAt >= startOfMonth ? costUsd : 0;
 
       const baseSession: Omit<AgentSessionAggregate, "endedAt"> = {
         sessionId: seedSession.sessionId,
@@ -289,17 +382,20 @@ export class DemoSimulator {
         lastActivityAt,
         status: isInactive ? "idle" : index % 3 === 0 ? "idle" : "active",
         totals: {
-          input: inputTokens,
-          output: outputTokens,
+          input: hasLongContext ? inputTokens + (longContextTokens?.input ?? 0) : inputTokens,
+          output: hasLongContext ? outputTokens + (longContextTokens?.output ?? 0) : outputTokens,
           cacheRead: Math.floor(tokens * 0.05),
           cacheWrite: Math.floor(tokens * 0.02),
         },
-        totalCostUsd: cost,
-        requestCount: Math.max(1, Math.floor(tokens / 700)),
+        totalCostUsd: costUsd,
+        requestCount: requestCount + longContextRequestCount,
         streams,
         costInDay,
         costInWeek,
         costInMonth,
+        _streamWindowedTokens: new Map([
+          [`${seedSession.providerId}::${seedSession.modelId}`, streamWindowedTokens],
+        ]),
       };
       if (seedSession.sessionName) {
         baseSession.sessionName = seedSession.sessionName;
@@ -317,6 +413,29 @@ export class DemoSimulator {
     this.providerUsage = new Map();
     this.lastTick = now;
     this.initializeProviderUsage(now);
+  }
+
+  private pickLongContextSessionIndexes(selectedSessions: DemoSessionSeed[]): Set<number> {
+    if (this.preset === "light") {
+      return new Set();
+    }
+
+    const activeIndexes = selectedSessions
+      .map((session, index) => ({ session, index }))
+      .filter(({ session }) => !(session.inactive ?? false))
+      .map(({ index }) => index);
+
+    const targetCount = this.preset === "normal" ? 1 : Math.min(2, activeIndexes.length);
+    const ranked = activeIndexes
+      .map((index) => ({
+        index,
+        score: this.rng
+          .fork(hashCombine(1_000 + index, selectedSessions[index]!.baseTokens))
+          .next(),
+      }))
+      .sort((a, b) => b.score - a.score || a.index - b.index);
+
+    return new Set(ranked.slice(0, targetCount).map(({ index }) => index));
   }
 
   private initializeProviderUsage(now: number) {

--- a/src/pricing/estimator.ts
+++ b/src/pricing/estimator.ts
@@ -1,5 +1,7 @@
 import type { CostBreakdown, ModelPricing } from "@tokentop/plugin-sdk";
 
+export const LONG_CONTEXT_THRESHOLD = 200_000;
+
 export interface TokenUsage {
   input: number;
   output: number;

--- a/src/pricing/estimator.ts
+++ b/src/pricing/estimator.ts
@@ -38,6 +38,11 @@ export function estimateCost(usage: TokenUsage, pricing: ModelPricing): CostBrea
   return breakdown;
 }
 
+/**
+ * @deprecated This function sums tokens before pricing, which is incompatible with
+ * tiered context-based pricing. Use per-request costing via priceStream() instead.
+ * Kept for backward compatibility — not called at runtime.
+ */
 export function estimateSessionCost(sessions: TokenUsage[], pricing: ModelPricing): CostBreakdown {
   const totals = sessions.reduce<TokenUsage>(
     (acc, session) => ({

--- a/src/pricing/index.ts
+++ b/src/pricing/index.ts
@@ -68,5 +68,10 @@ export function clearPricingCache(): void {
 }
 
 export type { TokenUsage } from "./estimator.ts";
+/**
+ * @deprecated This function sums tokens before pricing, which is incompatible with
+ * tiered context-based pricing. Use per-request costing via priceStream() instead.
+ * Kept for backward compatibility — not called at runtime.
+ */
 export { estimateCost, estimateSessionCost, formatCost, formatTokenCount } from "./estimator.ts";
 export { FALLBACK_PRICING } from "./fallback.ts";

--- a/src/pricing/models-dev.test.ts
+++ b/src/pricing/models-dev.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { clearCache, getModelPricing, getProviderModels } from "./models-dev.ts";
+
+const mockFetch = mock(() => Promise.resolve(new Response("null")));
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+function makeApiResponse(costOverride?: Record<string, unknown>) {
+  return {
+    anthropic: {
+      id: "anthropic",
+      name: "Anthropic",
+      models: {
+        "claude-sonnet-4-20250514": {
+          id: "claude-sonnet-4-20250514",
+          name: "Claude Sonnet 4",
+          family: "claude",
+          cost: {
+            input: 3,
+            output: 15,
+            cache_read: 0.3,
+            cache_write: 3.75,
+            ...costOverride,
+          },
+        },
+      },
+    },
+  };
+}
+
+function mockApiResponse(data: unknown) {
+  mockFetch.mockImplementation(() =>
+    Promise.resolve(new Response(JSON.stringify(data), { status: 200 })),
+  );
+}
+
+afterEach(() => {
+  clearCache();
+  mockFetch.mockClear();
+});
+
+describe("getModelPricing() — context_over_200k", () => {
+  test("returns all longContext fields when API has full context_over_200k", async () => {
+    mockApiResponse(
+      makeApiResponse({
+        context_over_200k: {
+          input: 6,
+          output: 22.5,
+          cache_read: 0.6,
+          cache_write: 7.5,
+        },
+      }),
+    );
+
+    const pricing = await getModelPricing("anthropic", "claude-sonnet-4-20250514");
+
+    expect(pricing).not.toBeNull();
+    expect(pricing!.longContextInput).toBe(6);
+    expect(pricing!.longContextOutput).toBe(22.5);
+    expect(pricing!.longContextCacheRead).toBe(0.6);
+    expect(pricing!.longContextCacheWrite).toBe(7.5);
+  });
+
+  test("returns undefined longContext fields when API lacks context_over_200k", async () => {
+    mockApiResponse(makeApiResponse());
+
+    const pricing = await getModelPricing("anthropic", "claude-sonnet-4-20250514");
+
+    expect(pricing).not.toBeNull();
+    expect(pricing!.longContextInput).toBeUndefined();
+    expect(pricing!.longContextOutput).toBeUndefined();
+    expect(pricing!.longContextCacheRead).toBeUndefined();
+    expect(pricing!.longContextCacheWrite).toBeUndefined();
+    expect(pricing!.input).toBe(3);
+    expect(pricing!.output).toBe(15);
+  });
+
+  test("handles partial context_over_200k (only input+output, no cache)", async () => {
+    mockApiResponse(
+      makeApiResponse({
+        context_over_200k: {
+          input: 6,
+          output: 22.5,
+        },
+      }),
+    );
+
+    const pricing = await getModelPricing("anthropic", "claude-sonnet-4-20250514");
+
+    expect(pricing).not.toBeNull();
+    expect(pricing!.longContextInput).toBe(6);
+    expect(pricing!.longContextOutput).toBe(22.5);
+    expect(pricing!.longContextCacheRead).toBeUndefined();
+    expect(pricing!.longContextCacheWrite).toBeUndefined();
+  });
+
+  test("getProviderModels() passes through longContext fields", async () => {
+    mockApiResponse(
+      makeApiResponse({
+        context_over_200k: {
+          input: 6,
+          output: 22.5,
+          cache_read: 0.6,
+        },
+      }),
+    );
+
+    const models = await getProviderModels("anthropic");
+
+    expect(models).not.toBeNull();
+    const pricing = models!["claude-sonnet-4-20250514"]!;
+    expect(pricing).toBeDefined();
+    expect(pricing.longContextInput).toBe(6);
+    expect(pricing.longContextOutput).toBe(22.5);
+    expect(pricing.longContextCacheRead).toBe(0.6);
+    expect(pricing.longContextCacheWrite).toBeUndefined();
+  });
+});

--- a/src/pricing/models-dev.ts
+++ b/src/pricing/models-dev.ts
@@ -94,6 +94,14 @@ export async function getModelPricing(
     pricing.cacheWrite = model.cost.cache_write;
   }
 
+  const lc = model.cost.context_over_200k;
+  if (lc) {
+    if (lc.input !== undefined) pricing.longContextInput = lc.input;
+    if (lc.output !== undefined) pricing.longContextOutput = lc.output;
+    if (lc.cache_read !== undefined) pricing.longContextCacheRead = lc.cache_read;
+    if (lc.cache_write !== undefined) pricing.longContextCacheWrite = lc.cache_write;
+  }
+
   return pricing;
 }
 
@@ -123,6 +131,14 @@ export async function getProviderModels(
     }
     if (model.cost.cache_write !== undefined) {
       pricing.cacheWrite = model.cost.cache_write;
+    }
+
+    const lc = model.cost.context_over_200k;
+    if (lc) {
+      if (lc.input !== undefined) pricing.longContextInput = lc.input;
+      if (lc.output !== undefined) pricing.longContextOutput = lc.output;
+      if (lc.cache_read !== undefined) pricing.longContextCacheRead = lc.cache_read;
+      if (lc.cache_write !== undefined) pricing.longContextCacheWrite = lc.cache_write;
     }
 
     result[modelId] = pricing;

--- a/src/pricing/models-dev.ts
+++ b/src/pricing/models-dev.ts
@@ -8,6 +8,12 @@ interface ModelsDevCost {
   output: number;
   cache_read?: number;
   cache_write?: number;
+  context_over_200k?: {
+    input?: number;
+    output?: number;
+    cache_read?: number;
+    cache_write?: number;
+  };
 }
 
 interface ModelsDevModel {

--- a/src/tui/components/SessionDetailsDrawer.tsx
+++ b/src/tui/components/SessionDetailsDrawer.tsx
@@ -158,6 +158,16 @@ export function SessionDetailsDrawer({ session, onClose: _onClose }: SessionDeta
     };
   }, [session.streams]);
 
+  const hasAnyLongContext = session.streams.some((s) => s.hasLongContext);
+  const totalLongContextRequests = session.streams.reduce(
+    (sum, s) => sum + (s.longContextRequestCount ?? 0),
+    0,
+  );
+  const totalLongContextTokens = session.streams.reduce((sum, s) => {
+    if (!s.longContextTokens) return sum;
+    return sum + s.longContextTokens.input + s.longContextTokens.output;
+  }, 0);
+
   const isMultiDay = session.lastActivityAt - session.startedAt > 24 * 60 * 60 * 1000;
   const startTimeStr = formatTimelineLabel(session.startedAt, isMultiDay);
   const endTimeStr = formatTimelineLabel(session.lastActivityAt, isMultiDay);
@@ -338,6 +348,18 @@ export function SessionDetailsDrawer({ session, onClose: _onClose }: SessionDeta
               </text>
             </box>
           )}
+
+          {hasAnyLongContext && (
+            <box flexDirection="row" height={1} marginBottom={0}>
+              <text height={1} overflow="hidden">
+                <span fg={colors.warning}>↑ Long ctx: </span>
+                <span fg={colors.text}>{totalLongContextRequests} reqs</span>
+                <span fg={colors.textMuted}> · </span>
+                <span fg={colors.text}>{formatTokens(totalLongContextTokens)} tokens</span>
+                <span fg={colors.textMuted}> at tiered rate</span>
+              </text>
+            </box>
+          )}
         </box>
 
         <box
@@ -407,11 +429,17 @@ export function SessionDetailsDrawer({ session, onClose: _onClose }: SessionDeta
                   </text>
                   <box width={10} height={1} justifyContent="flex-end">
                     <text fg={colors.textMuted}>
-                      {formatTokens(stream.tokens.input + stream.tokens.output)}
+                      {formatTokens(
+                        stream.tokens.input +
+                          stream.tokens.output +
+                          (stream.longContextTokens?.input ?? 0) +
+                          (stream.longContextTokens?.output ?? 0),
+                      )}
                     </text>
                   </box>
                   <box width={10} height={1} justifyContent="flex-end">
                     <text fg={colors.success}>{formatCost(stream.costUsd)}</text>
+                    <text fg={colors.textMuted}>{stream.hasLongContext ? "↑" : " "}</text>
                   </box>
                 </box>
               );

--- a/src/tui/components/SessionsTable.tsx
+++ b/src/tui/components/SessionsTable.tsx
@@ -159,6 +159,7 @@ const SessionRow = memo(function SessionRow({
   const cacheRead = session.totals.cacheRead ?? 0;
   const hasCacheData = cacheRead > 0;
   const isEstimated = session.metadata?.isEstimated === true;
+  const hasLongContext = session.streams.some((s) => s.hasLongContext === true);
   const costUsd = session.totalCostUsd ?? 0;
 
   const animatedTokens = useAnimatedValue(effectiveTokens, { durationMs: 300, precision: 0 });
@@ -271,8 +272,9 @@ const SessionRow = memo(function SessionRow({
           </span>
           <span fg={textMutedColor}>{hasCacheData ? ` ↯${formatCacheBadge(cacheRead)}` : ""}</span>
         </text>
-        <text width={8} height={1} fg={costColor} {...bgProp}>
-          {costDisplay.padStart(7)}
+        <text width={8} height={1} {...bgProp}>
+          <span fg={costColor}>{costDisplay.padStart(7)}</span>
+          <span fg={textMutedColor}>{hasLongContext ? "↑" : " "}</span>
         </text>
         <text width={14} height={1} fg={textSubtleColor} {...bgProp}>
           {projectDisplay}
@@ -329,8 +331,9 @@ const SessionRow = memo(function SessionRow({
           {hasCacheData && showCacheBadge ? ` ↯${formatCacheBadge(cacheRead)}` : ""}
         </span>
       </text>
-      <text width={7} height={1} fg={costColor} {...bgProp}>
-        {formatCostVal(costUsd).padStart(6)}
+      <text width={7} height={1} {...bgProp}>
+        <span fg={costColor}>{formatCostVal(costUsd).padStart(6)}</span>
+        <span fg={textMutedColor}>{hasLongContext ? "↑" : " "}</span>
       </text>
       <text flexGrow={1} height={1} fg={textSubtleColor} {...bgProp}>
         {projectDisplay}

--- a/src/tui/contexts/AgentSessionContext.tsx
+++ b/src/tui/contexts/AgentSessionContext.tsx
@@ -68,6 +68,9 @@ export function AgentSessionProvider({ children, autoRefresh = false }: AgentSes
   const { windowMs } = useTimeWindow();
   const hasBackfilled = useRef(false);
   const isRefreshingRef = useRef(false);
+  // Bugfix: track first completed load separately so an empty 1h window does not
+  // keep re-entering the initial loading state forever.
+  const hasLoadedOnceRef = useRef(false);
   const lastFingerprintRef = useRef<string>("");
 
   const discoverAgents = useCallback(async (): Promise<AgentInfo[]> => {
@@ -134,7 +137,7 @@ export function AgentSessionProvider({ children, autoRefresh = false }: AgentSes
       if (isRefreshingRef.current) return;
       isRefreshingRef.current = true;
 
-      const isInitialLoad = sessions.length === 0;
+      const isInitialLoad = !hasLoadedOnceRef.current;
       if (isInitialLoad) {
         setIsLoading(true);
       }
@@ -275,6 +278,7 @@ export function AgentSessionProvider({ children, autoRefresh = false }: AgentSes
         isRefreshingRef.current = false;
         if (isInitialLoad) {
           setIsLoading(false);
+          hasLoadedOnceRef.current = true;
         }
       }
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,6 @@
     "noImplicitOverride": true,
 
     // Path mapping
-    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,6 @@
     "noImplicitOverride": true,
 
     // Path mapping
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@plugins/*": ["./src/plugins/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "noImplicitOverride": true,
 
     // Path mapping
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],


### PR DESCRIPTION
## Summary

Implements tiered pricing support for models that charge higher rates when a request's context window exceeds 200K tokens (e.g., Anthropic Claude Sonnet/Opus 4.6 at 2× input/output). Closes #70.

## Changes

- **Plugin SDK** (`@tokentop/plugin-sdk`): Added optional `longContextInput?`, `longContextOutput?`, `longContextCacheRead?`, `longContextCacheWrite?` fields to `ModelPricing`
- **models.dev ingestion** (`src/pricing/models-dev.ts`): Parses `context_over_200k` from API response and maps to `longContext*` fields on `ModelPricing`
- **Aggregator** (`src/agents/aggregator.ts`): Derives `contextSize = input + cacheRead + cacheWrite` per request row; splits tokens into `base` (≤200K) and `longContext` (>200K) buckets
- **Costing** (`src/agents/costing.ts`): Calls `estimateCost()` twice per stream — once per bucket at the appropriate rate — and sums; windowed costs use per-bucket ratios (mathematically exact for single-tier pricing)
- **UI** (`src/tui/components/SessionsTable.tsx`): Shows `↑` indicator next to cost when `hasLongContext === true`
- **Demo mode** (`src/demo/simulator.ts`): Generates long-context sessions in `normal`/`heavy` presets so the indicator is visible in `ttop demo`
- **Deprecation** (`src/pricing/estimator.ts`): `estimateSessionCost()` marked `@deprecated` (sums tokens before pricing, incompatible with tiered pricing)
- **Tests**: New `costing.test.ts` (baseline + 7 tiered tests), extended `aggregator.test.ts` (+9 bucket-splitting tests), new `models-dev.test.ts` (4 ingestion tests)

## Type

- [x] `feat` — New feature

## Related issues

Closes #70

## Testing

- [x] `bun test` passes (158 tests, 0 failures)
- [x] `bun run typecheck` passes (zero errors)
- [x] Manual verification (describe below)

## Screenshots / captures

Demo mode (`ttop demo --seed 42`) shows `↑` indicator on long-context sessions:

```
OpenCode claude-3-5-sonn   256.4K ↯160   $182↑tokentop
OpenCode gpt-4.1             2.5K ↯105  $0.93 infra
Claude C…claude-3-opus       1.8K ↯90   $0.78 mobile
```

The `↑` appears after the cost on sessions where any stream exceeded the 200K context threshold.

### Architecture note

All tiered pricing data comes exclusively from models.dev `context_over_200k` field (53 models, 19 providers). No fallback tiered rates — if models.dev lacks the data for a model, base rates are used (conservative, never overcharges). Context size is derived in the core aggregator from existing `SessionUsageData` fields; no agent plugin changes required.